### PR TITLE
Update opensuse

### DIFF
--- a/opensuse
+++ b/opensuse
@@ -1,4 +1,4 @@
-FROM opensuse/latest
+FROM opensuse/leap:latest
 RUN  zypper install -y gcc-c++ openmpi-devel boost-devel python-mpi4py-devel python-devel python-pip cmake ccache fftw3-devel hdf5 hdf5-devel
 
 RUN useradd -m espressopp

--- a/opensuse
+++ b/opensuse
@@ -1,4 +1,4 @@
-FROM opensuse:latest
+FROM opensuse/latest
 RUN  zypper install -y gcc-c++ openmpi-devel boost-devel python-mpi4py-devel python-devel python-pip cmake ccache fftw3-devel hdf5 hdf5-devel
 
 RUN useradd -m espressopp


### PR DESCRIPTION
opensuse:latest is deprected in favour of opensuse/leap (https://hub.docker.com/_/opensuse/)