### PR TITLE
Add packages to fedora*

### DIFF
--- a/fedora
+++ b/fedora
@@ -1,6 +1,6 @@
 FROM fedora:latest
 ENV DEBIAN_FRONTEND noninteractive
-RUN dnf install -y make cmake wget git gcc-c++ doxygen python2-devel openmpi-devel environment-modules python-pip clang llvm compiler-rt ccache findutils boost-devel boost-python2-devel python2-sphinx fftw-devel python-matplotlib texlive-latex-bin graphviz boost-openmpi-devel ghostscript mpi4py-openmpi texlive-hyphen-base texlive-cm texlive-cmap texlive-ucs texlive-ec gromacs-devel hwloc-devel lmfit-devel ocl-icd-devel hdf5-devel python2-h5py
+RUN dnf install -y make cmake wget git gcc-c++ doxygen python2-devel openmpi-devel environment-modules python-pip clang llvm compiler-rt ccache findutils boost-devel boost-python2-devel python2-sphinx fftw-devel python-matplotlib texlive-latex-bin graphviz boost-openmpi-devel ghostscript mpi4py-openmpi texlive-hyphen-base texlive-cm texlive-cmap texlive-ucs texlive-ec gromacs-devel hwloc-devel lmfit-devel ocl-icd-devel hdf5-devel python2-h5py python2-numpy
 RUN wget -O /usr/bin/doxy-coverage https://raw.githubusercontent.com/alobbs/doxy-coverage/master/doxy-coverage.py
 RUN chmod +x /usr/bin/doxy-coverage
 

--- a/fedora
+++ b/fedora
@@ -1,6 +1,6 @@
 FROM fedora:latest
 ENV DEBIAN_FRONTEND noninteractive
-RUN dnf install -y make cmake wget git gcc-c++ doxygen python2-devel openmpi-devel environment-modules python-pip clang llvm compiler-rt ccache findutils boost-devel boost-python2-devel python2-sphinx fftw-devel python-matplotlib texlive-latex-bin graphviz boost-openmpi-devel ghostscript mpi4py-openmpi texlive-hyphen-base texlive-cm texlive-cmap texlive-ucs texlive-ec gromacs-devel hwloc-devel lmfit-devel ocl-icd-devel hdf5-devel python2-h5py atlas liblzf python-six python2-nose python2-numpy
+RUN dnf install -y make cmake wget git gcc-c++ doxygen python2-devel openmpi-devel environment-modules python-pip clang llvm compiler-rt ccache findutils boost-devel boost-python2-devel python2-sphinx fftw-devel python-matplotlib texlive-latex-bin graphviz boost-openmpi-devel ghostscript mpi4py-openmpi texlive-hyphen-base texlive-cm texlive-cmap texlive-ucs texlive-ec gromacs-devel hwloc-devel lmfit-devel ocl-icd-devel hdf5-devel python2-h5py atlas hdf5 liblzf python-six python2-nose python2-numpy
 RUN wget -O /usr/bin/doxy-coverage https://raw.githubusercontent.com/alobbs/doxy-coverage/master/doxy-coverage.py
 RUN chmod +x /usr/bin/doxy-coverage
 

--- a/fedora
+++ b/fedora
@@ -1,6 +1,6 @@
 FROM fedora:latest
 ENV DEBIAN_FRONTEND noninteractive
-RUN dnf install -y make cmake wget git gcc-c++ doxygen python2-devel openmpi-devel environment-modules python-pip clang llvm compiler-rt ccache findutils boost-devel boost-python2-devel python2-sphinx fftw-devel python-matplotlib texlive-latex-bin graphviz boost-openmpi-devel ghostscript mpi4py-openmpi texlive-hyphen-base texlive-cm texlive-cmap texlive-ucs texlive-ec gromacs-devel hwloc-devel lmfit-devel ocl-icd-devel hdf5-devel python2-h5py python2-numpy
+RUN dnf install -y make cmake wget git gcc-c++ doxygen python2-devel openmpi-devel environment-modules python-pip clang llvm compiler-rt ccache findutils boost-devel boost-python2-devel python2-sphinx fftw-devel python-matplotlib texlive-latex-bin graphviz boost-openmpi-devel ghostscript mpi4py-openmpi texlive-hyphen-base texlive-cm texlive-cmap texlive-ucs texlive-ec gromacs-devel hwloc-devel lmfit-devel ocl-icd-devel hdf5-devel python2-h5py atlas liblzf python-six python2-nose python2-numpy
 RUN wget -O /usr/bin/doxy-coverage https://raw.githubusercontent.com/alobbs/doxy-coverage/master/doxy-coverage.py
 RUN chmod +x /usr/bin/doxy-coverage
 

--- a/fedora_mpich
+++ b/fedora_mpich
@@ -1,6 +1,6 @@
 FROM fedora:latest
 ENV DEBIAN_FRONTEND noninteractive
-RUN dnf install -y make cmake wget git gcc-c++ doxygen python2-devel mpich-devel environment-modules python-pip clang llvm compiler-rt ccache findutils boost-devel boost-python2-devel python2-sphinx fftw-devel python-matplotlib texlive-latex-bin graphviz boost-mpich-devel ghostscript mpi4py-mpich texlive-hyphen-base texlive-cm texlive-cmap texlive-ucs texlive-ec gromacs-devel hwloc-devel lmfit-devel ocl-icd-devel hdf5-devel python2-h5py
+RUN dnf install -y make cmake wget git gcc-c++ doxygen python2-devel mpich-devel environment-modules python-pip clang llvm compiler-rt ccache findutils boost-devel boost-python2-devel python2-sphinx fftw-devel python-matplotlib texlive-latex-bin graphviz boost-mpich-devel ghostscript mpi4py-mpich texlive-hyphen-base texlive-cm texlive-cmap texlive-ucs texlive-ec gromacs-devel hwloc-devel lmfit-devel ocl-icd-devel hdf5-devel python2-h5py python2-numpy
 RUN wget -O /usr/bin/doxy-coverage https://raw.githubusercontent.com/alobbs/doxy-coverage/master/doxy-coverage.py
 RUN chmod +x /usr/bin/doxy-coverage
 

--- a/fedora_mpich
+++ b/fedora_mpich
@@ -1,6 +1,6 @@
 FROM fedora:latest
 ENV DEBIAN_FRONTEND noninteractive
-RUN dnf install -y make cmake wget git gcc-c++ doxygen python2-devel mpich-devel environment-modules python-pip clang llvm compiler-rt ccache findutils boost-devel boost-python2-devel python2-sphinx fftw-devel python-matplotlib texlive-latex-bin graphviz boost-mpich-devel ghostscript mpi4py-mpich texlive-hyphen-base texlive-cm texlive-cmap texlive-ucs texlive-ec gromacs-devel hwloc-devel lmfit-devel ocl-icd-devel hdf5-devel python2-h5py atlas liblzf python-six python2-nose python2-numpy
+RUN dnf install -y make cmake wget git gcc-c++ doxygen python2-devel mpich-devel environment-modules python-pip clang llvm compiler-rt ccache findutils boost-devel boost-python2-devel python2-sphinx fftw-devel python-matplotlib texlive-latex-bin graphviz boost-mpich-devel ghostscript mpi4py-mpich texlive-hyphen-base texlive-cm texlive-cmap texlive-ucs texlive-ec gromacs-devel hwloc-devel lmfit-devel ocl-icd-devel hdf5-devel python2-h5py atlas hdf5 liblzf python-six python2-nose python2-numpy
 RUN wget -O /usr/bin/doxy-coverage https://raw.githubusercontent.com/alobbs/doxy-coverage/master/doxy-coverage.py
 RUN chmod +x /usr/bin/doxy-coverage
 

--- a/fedora_mpich
+++ b/fedora_mpich
@@ -1,6 +1,6 @@
 FROM fedora:latest
 ENV DEBIAN_FRONTEND noninteractive
-RUN dnf install -y make cmake wget git gcc-c++ doxygen python2-devel mpich-devel environment-modules python-pip clang llvm compiler-rt ccache findutils boost-devel boost-python2-devel python2-sphinx fftw-devel python-matplotlib texlive-latex-bin graphviz boost-mpich-devel ghostscript mpi4py-mpich texlive-hyphen-base texlive-cm texlive-cmap texlive-ucs texlive-ec gromacs-devel hwloc-devel lmfit-devel ocl-icd-devel hdf5-devel python2-h5py python2-numpy
+RUN dnf install -y make cmake wget git gcc-c++ doxygen python2-devel mpich-devel environment-modules python-pip clang llvm compiler-rt ccache findutils boost-devel boost-python2-devel python2-sphinx fftw-devel python-matplotlib texlive-latex-bin graphviz boost-mpich-devel ghostscript mpi4py-mpich texlive-hyphen-base texlive-cm texlive-cmap texlive-ucs texlive-ec gromacs-devel hwloc-devel lmfit-devel ocl-icd-devel hdf5-devel python2-h5py atlas liblzf python-six python2-nose python2-numpy
 RUN wget -O /usr/bin/doxy-coverage https://raw.githubusercontent.com/alobbs/doxy-coverage/master/doxy-coverage.py
 RUN chmod +x /usr/bin/doxy-coverage
 


### PR DESCRIPTION
The packages `atlas`, `hdf5`, `liblzf`, `python-six`, `python2-h5py`, `python2-nose` and `python2-numpy` are added to the fedora builds. Related to #19 