### PR TITLE
.travis.yml: drop fedora

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ services:
 
 env:
   matrix:
-    - DISTRO=fedora DOCKERHUB=true
+#    - DISTRO=fedora DOCKERHUB=true
     - DISTRO=ubuntu DOCKERHUB=true
     - DISTRO=ubuntu_rolling DOCKERHUB=true
-    - DISTRO=fedora_mpich DOCKERHUB=true
+#    - DISTRO=fedora_mpich DOCKERHUB=true
     - DISTRO=ubuntu_mpich DOCKERHUB=true
     - DISTRO=opensuse DOCKERHUB=true
 


### PR DESCRIPTION
Fedora dropped python2 support, so drop it until https://github.com/espressopp/espressopp/issues/227 is fixed.