### PR TITLE
opensuse: use tumbleweed instead of leap

### DIFF
--- a/opensuse
+++ b/opensuse
@@ -1,4 +1,4 @@
-FROM opensuse/leap:latest
+FROM opensuse/tumbleweed:latest
 RUN zypper install -y gcc-c++ openmpi2-devel boost-devel libboost_filesystem-devel \
     libboost_mpi-devel libboost_python3-devel libboost_serialization-devel \
     libboost_system-devel libboost_test-devel \


### PR DESCRIPTION
Boost is too old in leap, so let's use tumbleweed.