### PR TITLE
fedora: use icpc from intel-oneapi

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -24,7 +24,6 @@ jobs:
           - {dockerfile: 'ubuntu',   tag: 'ubuntu_devel',        build_args: 'TAG=devel', continue-on-error: 'true'}
           - {dockerfile: 'opensuse', tag: 'opensuse',            continue-on-error: 'true'}
           - {dockerfile: 'fedora',   tag: 'fedora_intel',        build_args: 'TAG=33,INTEL=yes'}
-          - {dockerfile: 'fedora',   tag: 'fedora_intel-oneapi', build_args: 'INTEL_ONEAPI=yes'}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout out code

--- a/fedora
+++ b/fedora
@@ -3,7 +3,6 @@ FROM registry.fedoraproject.org/fedora:${TAG}
 
 ARG PYTHON=python3.9
 ARG INTEL
-ARG INTEL_ONEAPI
 ARG MPI=openmpi
 
 RUN ( dnf -y update || dnf -y update ) && \
@@ -19,25 +18,10 @@ RUN ( dnf -y update || dnf -y update ) && \
     python-six python-nose python-numpy texlive-amsmath texlive-amsfonts sudo texlive-babel texlive-psnfss texlive-fncychap && \
     dnf clean all
 
-RUN if [ -n "${INTEL}" ]; then \
-  mkdir -p /var/lib/yum/intel-icc && \
-  pushd /var/lib/yum/intel-icc && \
-  wget --no-verbose https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/17114/parallel_studio_xe_2020_update4_professional_edition.tgz && \
-  tar -xf parallel_studio_xe_*.tgz && \
-  rm parallel_studio_xe_*.tgz && \
-  cd parallel_studio_xe_*/rpm && \
-  printf "[icc]\nname=icc\nbaseurl=$PWD\nenabled=1" > /etc/yum.repos.d/icc.repo && \
-  rpm --import ../PUBLIC_KEY.PUB && \
-  ( dnf -y update || dnf -y update ) && \
-  dnf -y install intel-parallel-studio-xe-icc intel-parallel-studio-xe-mkl && \
-  dnf clean all && \
-  mkdir /opt/intel/licenses; \
-fi
-
-RUN if [ "${INTEL_ONEAPI}" = "yes" ]; then \
+RUN if [ "${INTEL}" = "yes" ]; then \
   printf "[oneAPI]\nname=Intel oneAPI\nbaseurl=https://yum.repos.intel.com/oneapi\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB" > /etc/yum.repos.d/intel-oneapi.repo && \
   ( dnf -y update || dnf -y update ) && \
-  dnf -y install intel-oneapi-compiler-dpcpp-cpp intel-oneapi-mkl && \
+  dnf -y install intel-oneapi-compiler-dpcpp-cpp intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-mkl-devel && \
   dnf clean all; \
 fi
 
@@ -47,10 +31,8 @@ RUN echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER espressopp
 ENV PATH=/usr/lib64/ccache:${PATH}${PATH:+:}/usr/lib64/${MPI}/bin/
 ENV LD_LIBRARY_PATH=/usr/lib64/${MPI}/lib${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}
-ENV PATH=${INTEL:+/opt/intel/bin/:}${PATH:+:}${PATH}
-ENV LD_LIBRARY_PATH=${INTEL:+/opt/intel/lib/intel64:/opt/intel/mkl/lib/intel64}${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}
-ENV PATH=${INTEL_ONEAPI:+/opt/intel/oneapi/compiler/latest/linux/bin:}${PATH:+:}${PATH}
-ENV LD_LIBRARY_PATH=${INTEL_ONEAPI:+/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64:/opt/intel/oneapi/mkl/latest/lib/intel64}${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}
+ENV PATH=${INTEL:+/opt/intel/oneapi/compiler/latest/linux/bin:/opt/intel/oneapi/compiler/latest/linux/bin/intel64}${PATH:+:}${PATH}
+ENV LD_LIBRARY_PATH=${INTEL:+/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64:/opt/intel/oneapi/mkl/latest/lib/intel64}${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}
 RUN XPYTHON=$(basename $(readlink -f /usr/bin/python3)); if [[ ${XPYTHON} != ${PYTHON} ]]; then echo "PYTHON default needs update (is currently ${PYTHON}, but found ${XPYTHON})"; exit 1; fi
 ENV PYTHONPATH=/usr/lib64/${PYTHON}/site-packages/${MPI}${PYTHONPATH:+:}${PYTHONPATH}
 WORKDIR /home/espressopp


### PR DESCRIPTION
No more hard-coded urls and one less build