### PR TITLE
remove pre-installed python packages and rely on requirements.txt

### DIFF
--- a/fedora
+++ b/fedora
@@ -8,14 +8,14 @@ ARG MPI=openmpi
 RUN ( dnf -y update || dnf -y update ) && \
     dnf -y install make cmake wget git gcc-c++ doxygen python-devel \
     ${MPI}-devel environment-modules python-pip clang llvm compiler-rt \
-    ccache findutils boost-devel boost-python3-devel python-sphinx fftw-devel \
-    python-matplotlib texlive-latex-bin graphviz boost-${MPI}-devel latexmk \
+    ccache findutils boost-devel boost-python3-devel fftw-devel \
+    texlive-latex-bin graphviz boost-${MPI}-devel latexmk \
     texlive-fancyhdr texlive-titlesec texlive-capt-of texlive-courier texlive-dvips texlive-fancyvrb texlive-framed texlive-gsftopk \
     texlive-helvetic texlive-makeindex texlive-needspace texlive-parskip texlive-tabulary texlive-times texlive-upquote \
     texlive-varwidth texlive-wrapfig python3-coverage \
     ghostscript python3-mpi4py-${MPI} texlive-hyphen-base texlive-cm texlive-cmap texlive-fncychap \
     texlive-ucs texlive-ec gromacs-devel hwloc-devel lmfit-devel ocl-icd-devel python-h5py-${MPI} atlas hdf5-${MPI}-devel liblzf \
-    python-six python-nose python-numpy texlive-amsmath texlive-amsfonts sudo texlive-babel texlive-psnfss texlive-fncychap && \
+    texlive-amsmath texlive-amsfonts sudo texlive-babel texlive-psnfss texlive-fncychap && \
     dnf clean all
 
 RUN if [ "${INTEL}" = "yes" ]; then \

--- a/ubuntu
+++ b/ubuntu
@@ -13,10 +13,10 @@ RUN apt-get update && \
     fi && \
     apt-get install -y build-essential libfftw3-dev \
     python3-dev \
-    libboost-all-dev git python3-mpi4py cmake wget python3-numpy ipython3 \
-    clang llvm ccache python3-pip doxygen sphinx-common python3-matplotlib \
+    libboost-all-dev git cmake wget \
+    clang llvm ccache python3-pip doxygen sphinx-common \
     graphviz texlive-latex-base texlive-latex-extra texlive-latex-recommended \
-    ghostscript libgromacs-dev clang-format curl latexmk libhdf5-${MPI}-dev hdf5-tools python3-h5py sudo && \
+    ghostscript libgromacs-dev clang-format curl latexmk libhdf5-${MPI}-dev hdf5-tools sudo && \
     apt-get purge --autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Remove preinstalled python dependencies and rely on `pip install -r requirements.txt`.

closes #49 
