### PR TITLE
Revert "opensuse: add openmpi2 workaround"

### DIFF
--- a/opensuse
+++ b/opensuse
@@ -18,8 +18,6 @@ RUN echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER espressopp
 ENV PATH=/usr/lib64/ccache:/usr/lib64/mpi/gcc/${MPI}/bin${PATH:+:}${PATH}
 ENV LD_LIBRARY_PATH=/usr/lib64/mpi/gcc/${MPI}/lib64${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}
-#workaround for hard-coded openmpi2 linkage in some packages
-ENV LD_LIBRARY_PATH=/usr/lib64/mpi/gcc/openmpi2/lib64${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}
 RUN XPYTHON=$(basename $(readlink -f /usr/bin/python3)); if [[ ${XPYTHON} != ${PYTHON} ]]; then echo "PYTHON default needs update (is currently ${PYTHON}, but found ${XPYTHON})"; exit 1; fi
 ENV PYTHONPATH=/usr/lib64/mpi/gcc/${MPI}/lib64/${PYTHON}/site-packages${PYTHONPATH:+:}${PYTHONPATH}
 WORKDIR /home/espressopp


### PR DESCRIPTION
This reverts commit 2b489baebff1cc2db965fa328138e36fd5d4e963.